### PR TITLE
Relax python-dotenv pin to allow patched versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sentry-sdk==2.20.0
 boto3==1.36.0
 aioboto3==13.4.0
-python-dotenv==1.0.1
+python-dotenv>=1.0.0,<2.0

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 """
 pip setup file
 """
+
 from setuptools import find_packages, setup
 
 from clever_events_library import __version__


### PR DESCRIPTION
## Summary

The hard pin `python-dotenv==1.0.1` in `requirements.txt` (which feeds `install_requires`) prevents every consumer of this library from upgrading python-dotenv past 1.0.1. That keeps **CVE-2026-28684** (fixed in 1.2.2) open in downstream container images — it currently blocks remediation in [messaging-service#122](https://github.com/clever-real-estate/messaging-service/pull/122).

This relaxes the pin to `>=1.0.0,<2.0`: consumers can upgrade, and nothing forces an immediate upgrade on consumers still resolving 1.0.x, so there's no merge-ordering hazard.

## Safety

The library's only dotenv usage is `load_dotenv()` in `clever_events_library/mixins.py`, which is stable across all of 1.x. The CVE itself is in `set_key()`/`unset_key()`, which this library never calls.

## Verification

All 18 tests pass locally with python-dotenv resolving to 1.2.2.

## Note

`sentry-sdk==2.20.0`, `boto3==1.36.0`, and `aioboto3==13.4.0` are also hard-pinned here and will cause the same class of conflict for consumers eventually — worth relaxing to ranges in a follow-up.