### PR TITLE
Update python-dotenv pin to 1.2.3 (PYSEC-2026-2270)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sentry-sdk==2.20.0
 boto3==1.36.0
 aioboto3==13.4.0
-python-dotenv==1.0.1
+python-dotenv==1.2.3

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 """
 pip setup file
 """
+
 from setuptools import find_packages, setup
 
 from clever_events_library import __version__


### PR DESCRIPTION
## Summary

Updates the `python-dotenv` pin in `requirements.txt` from `1.0.1` to `1.2.3`.

- python-dotenv 1.0.1 has a known vulnerability, **PYSEC-2026-2270** (fixed in python-dotenv 1.2.2).
- This reapplies the intent of closed PR #6, but with an **exact pin** per the repo owner's preference for exact version pins (PR #6 proposed a range).
- Downstream **messaging-service** installs this library from GitHub HEAD and needs this change to clear its last AWS Inspector finding.

## Changes

- `requirements.txt`: `python-dotenv==1.0.1` → `python-dotenv==1.2.3` (the only place the version is declared; `setup.py` reads `requirements.txt`, `setup.cfg` lists python-dotenv unversioned)

## QA

- Full test suite: `python -m unittest discover` — **18/18 tests pass** with python-dotenv 1.2.3 installed
- Packaging: wheel builds via `python -m build --wheel` and installs cleanly into a fresh venv; `import clever_events_library` works and `importlib.metadata` reports python-dotenv 1.2.3 with declared requirement `python-dotenv==1.2.3`
- No remaining references to `1.0.1` anywhere in the repo